### PR TITLE
Fix style section closure

### DIFF
--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -5,6 +5,8 @@
             @apply text-red-500 text-sm/6 mt-3
         }
     </style>
+@endsection
+
 @section('content')
     <form action="{{ isset($task) ? route('tasks.update',['task' => $task]) : route('tasks.store') }}" method="POST">
         <div class="space-y-12">


### PR DESCRIPTION
## Summary
- close the `styles` section in `form.blade.php`
- start the `content` section on a new line

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ada9593048327955f9e48d8186bab